### PR TITLE
script to delete PostTag entry when Tag deleted

### DIFF
--- a/updateScript3.sql
+++ b/updateScript3.sql
@@ -1,0 +1,8 @@
+﻿ALTER TABLE PostTag
+   DROP CONSTRAINT FK_PostTag_Tag;
+
+ALTER TABLE PostTag
+    ADD CONSTRAINT FK_PostTag_Tag
+    FOREIGN KEY (TagId)
+    REFERENCES Tag (Id)
+    ON DELETE CASCADE;


### PR DESCRIPTION
### Desc
Added script to delete entr from PostTag table when a Tag is deleted. 
This PR addresses part of issue #24 
### Testing Instructions
Steps:
Run the script in a new SQL query.
Verify if upon deleting a tag the entry from PostTag table for that tag is deleted.