### PR TITLE
prevent adding dup tags to post

### DIFF
--- a/TabloidCLI/Repositories/PostRepository.cs
+++ b/TabloidCLI/Repositories/PostRepository.cs
@@ -214,10 +214,11 @@ namespace TabloidCLI.Repositories
             using (SqlConnection conn = Connection)
             {
                 conn.Open();
+
                 using (SqlCommand cmd = conn.CreateCommand())
-                {
+                {           
                     cmd.CommandText = @"INSERT INTO PostTag (PostId, TagId)
-                                                        VALUES (@postId, @tagId)";
+                                            VALUES (@postId, @tagId)";
                     cmd.Parameters.AddWithValue("@postId", post.Id);
                     cmd.Parameters.AddWithValue("@tagId", inputTag.Id);
                     cmd.ExecuteNonQuery();
@@ -238,6 +239,35 @@ namespace TabloidCLI.Repositories
                     cmd.Parameters.AddWithValue("@tagId", tagId);
 
                     cmd.ExecuteNonQuery();
+                }
+            }
+        }
+
+        public Post GetPostByTagId(int tagid)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = "SELECT PostId FROM PostTag WHERE TagId = @tagid";
+                    cmd.Parameters.AddWithValue("@tagid", tagid);
+
+                    using (SqlDataReader reader = cmd.ExecuteReader())
+                    {
+                        Post post = null;
+
+                        // If we only expect a single row back from the database, we don't need a while loop.
+                        if (reader.Read())
+                        {
+                            post = new Post
+                            {
+                                Id = reader.GetInt32(reader.GetOrdinal("PostId"))
+                            };
+                        }
+                        return post;
+                    }
+
                 }
             }
         }

--- a/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
@@ -97,7 +97,13 @@ namespace TabloidCLI.UserInterfaceManagers
             {
                 int choice = int.Parse(input);
                 Tag tag = tags[choice - 1];
-                _postRepository.InsertTag(post, tag);
+
+                // avoid adding duplicate entries to the PostTag table
+                Post postWithSameTag = _postRepository.GetPostByTagId(tag.Id);
+                if (postWithSameTag == null)
+                {
+                    _postRepository.InsertTag(post, tag);
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### Desc
Added functionality to prevent adding duplicate tags to the post.
### Testing Instructions
Steps:
1. Select option (4) Post Management from the main menu
2. Select option (1) List Posts from Post Management
3. Select a post from the list displayed
4. Select option (2) Add Tag from the Post Details Menu
5. Select a tag from the list of tags
If the post already has this tag it should bot be added to the post again.
You can verify if the tag is added by looking at the PostTag table in the SQL Server Object Explorer in Visual Studio.
The table should NOT have a duplicate entry with same postId and tagId.
